### PR TITLE
samples: matter: Fixed dfu over smp upload callback

### DIFF
--- a/doc/nrf/gs_installing.rst
+++ b/doc/nrf/gs_installing.rst
@@ -381,7 +381,7 @@ It also includes additional host tools, such as custom QEMU and OpenOCD builds.
 .. ncs-include:: develop/getting_started/index.rst
    :docset: zephyr
    :dedent: 0
-   :start-after: and OpenOCD builds.
+   :start-after: debug Zephyr applications.
    :end-before: .. _getting_started_run_sample:
 
 .. rst-class:: numbered-step

--- a/lib/nrf_modem_lib/nrf91_sockets.c
+++ b/lib/nrf_modem_lib/nrf91_sockets.c
@@ -1317,7 +1317,7 @@ static void nrf91_socket_iface_init(struct net_if *iface)
 {
 	nrf91_socket_iface_data.iface = iface;
 
-	iface->if_dev->offloaded = true;
+	iface->if_dev->socket_offload = nrf91_socket_create;
 
 	socket_offload_dns_register(&nrf91_socket_dns_offload_ops);
 }

--- a/samples/matter/common/src/dfu_over_smp.cpp
+++ b/samples/matter/common/src/dfu_over_smp.cpp
@@ -32,7 +32,7 @@ void DFUOverSMP::Init(DFUOverSMPRestartAdvertisingHandler startAdvertisingCb)
 {
 	os_mgmt_register_group();
 	img_mgmt_register_group();
-	img_mgmt_set_upload_cb(UploadConfirmHandler, NULL);
+	img_mgmt_set_upload_cb(UploadConfirmHandler);
 
 	memset(&mBleConnCallbacks, 0, sizeof(mBleConnCallbacks));
 	mBleConnCallbacks.connected = OnBleConnect;
@@ -61,10 +61,11 @@ void DFUOverSMP::ConfirmNewImage()
 	}
 }
 
-int DFUOverSMP::UploadConfirmHandler(uint32_t offset, uint32_t size, void *arg)
+int DFUOverSMP::UploadConfirmHandler(const struct img_mgmt_upload_req req,
+				  const struct img_mgmt_upload_action action)
 {
 	/* For now just print update progress and confirm data chunk without any additional checks. */
-	ChipLogProgress(DeviceLayer, "Software update progress %d B / %d B", offset, size);
+	ChipLogProgress(DeviceLayer, "Software update progress of image %d: %d B / %d B", req.image, req.off, action.size);
 
 	return 0;
 }

--- a/samples/matter/common/src/dfu_over_smp.h
+++ b/samples/matter/common/src/dfu_over_smp.h
@@ -23,7 +23,8 @@ public:
 private:
 	friend DFUOverSMP &GetDFUOverSMP(void);
 
-	static int UploadConfirmHandler(uint32_t offset, uint32_t size, void *arg);
+	static int UploadConfirmHandler(const struct img_mgmt_upload_req req,
+				  const struct img_mgmt_upload_action action);
 	static void OnBleConnect(bt_conn *conn, uint8_t err);
 	static void OnBleDisconnect(bt_conn *conn, uint8_t reason);
 	static void ChipEventHandler(const chip::DeviceLayer::ChipDeviceEvent *event, intptr_t arg);

--- a/scripts/west_commands/ncs_commands.py
+++ b/scripts/west_commands/ncs_commands.py
@@ -511,5 +511,6 @@ _BLOCKED_PROJECTS = set(
      'modules/hal/telink',
      'modules/hal/ti',
      'modules/hal/xtensa',
+     'modules/lib/picolibc',
      'modules/lib/tflite-micro',
      ])

--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 85a0034809612b332fbdf478357e8a4109c493fd
+      revision: pull/838/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -100,7 +100,7 @@ manifest:
     # changes.
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: v1.9.99-ncs1
+      revision: pull/205/head
       path: bootloader/mcuboot
     - name: mbedtls-nrf
       path: mbedtls


### PR DESCRIPTION
Fixed img_mgmt_set_upload_cb callback in Matter samples
after last Zephyr's changes.

Fixes Matter samples build in: https://github.com/nrfconnect/sdk-nrf/pull/8056

Signed-off-by: Arkadiusz Balys <arkadiusz.balys@nordicsemi.no>